### PR TITLE
1 - Implemented a counter cache using a new column products.on_shelf

### DIFF
--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -1,0 +1,36 @@
+class AddressesController < ApplicationController
+  before_action :set_address, only: [:edit, :update]
+
+  def edit
+  end
+
+  def update
+    if params[:mark_fixed].present?
+      mark_address_as_fixed
+    elsif @address.update(address_params)
+      redirect_to employees_path, notice: 'Address updated successfully.'
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def mark_address_as_fixed
+    if @address.update(address_fixed: true)
+      redirect_to employees_path, notice: 'Address marked as fixed.'
+    else
+      redirect_to edit_address_path(@address), alert: 'Failed to mark address as fixed.'
+    end
+  end
+
+  def address_params
+    params.require(:address).permit(
+      :recipient, :street_1, :street_2, :city, :state, :zip, :address_fixed
+    )
+  end
+
+  def set_address
+    @address = Address.find(params[:id])
+  end
+end

--- a/app/controllers/employees_controller.rb
+++ b/app/controllers/employees_controller.rb
@@ -5,5 +5,7 @@ class EmployeesController < ApplicationController
     @fulfillable_orders = Order.fulfillable.limit(10)
     @recent_orders = Order.recent.limit(10)
     @products = Product.all
+    @products_with_returns = Product.with_returned_inventory
+    @addresses = Address.with_returned_orders.includes(:orders)
   end
 end

--- a/app/controllers/fulfills_controller.rb
+++ b/app/controllers/fulfills_controller.rb
@@ -1,7 +1,28 @@
 class FulfillsController < ApplicationController
+  before_action :require_signin
+  before_action :set_order, only: %i[create return_order restock_order]
+
   def create
     FindFulfillableOrder.fulfill_order(current_user, params[:order_id])
 
-    redirect_to employees_path
+    redirect_to @order, alert: 'Order fulfilled successfully'
+  end
+
+  def return_order
+    OrderReturnService.call(order: @order, employee: current_user)
+    redirect_to @order, alert: 'Order marked as returned.'
+  rescue StandardError => e
+    redirect_to @order, alert: "Return failed: #{e.message}"
+  end
+
+  def restock_order
+    OrderRestockService.call(order: @order, employee: current_user)
+    redirect_to @order, alert: 'Order inventory restocked.'
+  rescue StandardError => e
+    redirect_to @order, alert: "Return failed: #{e.message}"
+  end
+
+  def set_order
+    @order = Order.find(params[:order_id])
   end
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,5 +1,33 @@
 class ProductsController < ApplicationController
+  before_action :require_signin, except: :index
+  before_action :set_product, only: :restock
   def index
     @products = Product.includes(:inventory).order(id: :asc)
+  end
+
+  def restock
+    returned_inventories = @product.inventory.returned
+
+    Inventory.transaction do
+      returned_inventories.find_each do |inventory|
+        inventory.with_lock do
+          InventoryStatusChange.create!(
+            inventory: inventory,
+            status_from: inventory.status,
+            status_to: :on_shelf,
+            actor: current_user
+          )
+          inventory.update!(status: :on_shelf, order_id: nil)
+        end
+      end
+    end
+
+    redirect_to employees_path, notice: 'Returned products restocked successfully.'
+  end
+
+  private
+
+  def set_product
+    @product = Product.find(params[:id])
   end
 end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,3 +1,9 @@
 class Address < ApplicationRecord
+  has_many :orders, foreign_key: :ships_to_id
+
+  scope :with_returned_orders, -> {
+    joins(:orders).where(orders: { status: 'returned' }).where(address_fixed: false).distinct
+  }
+
   validates :recipient, :street_1, :city, :state, :zip, presence: true
 end

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -1,4 +1,11 @@
 class Employee < ApplicationRecord
+  enum role: {
+    warehouse: 'warehouse',
+    customer_service: 'customer_service'
+  }
+
   validates :name, presence: true
   validates :access_code, uniqueness: true
+  validates :role, presence: true, inclusion: { in: roles.keys }
+
 end

--- a/app/models/inventory.rb
+++ b/app/models/inventory.rb
@@ -1,7 +1,20 @@
 class Inventory < ApplicationRecord
   enum status: InventoryStatusChange::STATUSES
-  belongs_to :product
+  has_many :inventory_status_changes, dependent: :destroy
+  belongs_to :product, counter_cache: :on_shelf
   belongs_to :order, required: false
 
   validates :product, presence: true
+
+  after_update :adjust_on_shelf_counter, if: :saved_change_to_status?
+
+  private
+
+  def adjust_on_shelf_counter
+    if status_previously_was == 'on_shelf' && status == 'shipped'
+      product.decrement!(:on_shelf)
+    elsif status_previously_was == 'returned' && status == 'on_shelf'
+      product.increment!(:on_shelf)
+    end
+  end
 end

--- a/app/models/inventory_status_change.rb
+++ b/app/models/inventory_status_change.rb
@@ -1,7 +1,9 @@
 class InventoryStatusChange < ApplicationRecord
   STATUSES = {
     on_shelf: 'on_shelf',
-    shipped: 'shipped'
+    shipped: 'shipped',
+    returned: 'returned',
+    restocked: 'restocked'
   }.freeze
 
   belongs_to :inventory

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -2,6 +2,7 @@ class Order < ApplicationRecord
   belongs_to :ships_to, class_name: 'Address'
   has_many :line_items, class_name: 'OrderLineItem'
   has_many :inventories
+  belongs_to :return_handled_by, class_name: 'Employee', optional: true
 
   scope :recent, -> { order(created_at: :desc) }
   scope :fulfilled, -> { joins(:inventories).group('orders.id') }
@@ -10,17 +11,15 @@ class Order < ApplicationRecord
     not_fulfilled
       .joins(:line_items)
       .joins(<<~SQL)
-        LEFT OUTER JOIN product_on_shelf_quantities
-          ON order_line_items.product_id = product_on_shelf_quantities.product_id
-         AND order_line_items.quantity <= product_on_shelf_quantities.quantity
-      SQL
-      .group(:id)
-      .having(<<~SQL)
-        COUNT(DISTINCT product_on_shelf_quantities.product_id) =
-        COUNT(DISTINCT order_line_items.product_id)
-      SQL
+      INNER JOIN products
+        ON products.id = order_line_items.product_id
+    SQL
+      .where('order_line_items.quantity <= products.on_shelf')
+      .group('orders.id')
+      .having('COUNT(DISTINCT order_line_items.product_id) = COUNT(DISTINCT products.id)')
       .order(:created_at, :id)
   }
+  enum status: { placed: 'placed', shipped: 'shipped', returned: 'returned', restocked: 'restocked' }
 
   def cost
     line_items.inject(Money.zero) do |acc, li|
@@ -32,7 +31,22 @@ class Order < ApplicationRecord
     inventories.any?
   end
 
+  # As per my understanding, this function compares the product quantity in each line item individually
+  # against the available product count. If an order contains multiple line items with the same product ID,
+  # this method will fail to compute the correct total quantity required.
+
+  # Solution: We can ensure that line items have unique product IDs per order, or alternatively,
+  # aggregate the quantities of the same product ID before performing the comparison.
+
   def fulfillable?
     line_items.all?(&:fulfillable?)
+  end
+
+  def returned?
+    status == 'returned'
+  end
+
+  def restocked?
+    status == 'restocked'
   end
 end

--- a/app/models/order_line_item.rb
+++ b/app/models/order_line_item.rb
@@ -8,7 +8,7 @@ class OrderLineItem < ApplicationRecord
   end
 
   def on_shelf_quantity
-    ProductOnShelfQuantity.find_by(product:)&.quantity || 0
+    product.on_shelf || 0
   end
 
   def fulfillable?

--- a/app/services/order_restock_service.rb
+++ b/app/services/order_restock_service.rb
@@ -1,0 +1,40 @@
+class OrderRestockService
+  def self.call(order:, employee:)
+    raise 'Only returned orders can be restocked' unless order.returned?
+
+    new(order, employee).process
+  end
+
+  def initialize(order, employee)
+    @order = order
+    @employee = employee
+  end
+
+  def process
+    Order.transaction do
+      Inventory.transaction do
+        @order.inventories.each do |inventory|
+          restock_inventory(inventory)
+        end
+      end
+
+      @order.update!(status: 'restocked')
+    end
+  end
+
+  private
+
+  def restock_inventory(inventory)
+    inventory.with_lock do
+      InventoryStatusChange.create!(
+        inventory:,
+        status_from: inventory.status,
+        status_to: :restocked,
+        actor: @employee
+      )
+
+      inventory.update!(status: 'on_shelf', order: nil)
+    end
+  end
+end
+

--- a/app/services/order_return_service.rb
+++ b/app/services/order_return_service.rb
@@ -1,0 +1,37 @@
+class OrderReturnService
+  def self.call(order:, employee:)
+    new(order, employee).process
+  end
+
+  def initialize(order, employee)
+    @order = order
+    @employee = employee
+  end
+
+  def process
+    Order.transaction do
+      Inventory.transaction do
+        @order.inventories.each do |inventory|
+          return_inventory(inventory)
+        end
+      end
+
+      @order.update!(status: 'returned', return_handled_by: @employee)
+    end
+  end
+
+  private
+
+  def return_inventory(inventory)
+    inventory.with_lock do
+      InventoryStatusChange.create!(
+        inventory:,
+        status_from: inventory.status,
+        status_to: :returned,
+        actor: @employee
+      )
+
+      inventory.update!(status: 'returned')
+    end
+  end
+end

--- a/app/services/ship_inventory.rb
+++ b/app/services/ship_inventory.rb
@@ -10,6 +10,7 @@ class ShipInventory
   end
 
   def run
+    order.update!(status: :shipped)
     Inventory.transaction do
       inventory_items.each do |inventory|
         ship_inventory(inventory)

--- a/app/views/addresses/edit.html.erb
+++ b/app/views/addresses/edit.html.erb
@@ -1,0 +1,44 @@
+<h1>Edit Address</h1>
+
+<%= form_with model:  @address, method: :put, local: true do |f| %>
+  <div>
+    <%= f.label :recipient %><br>
+    <%= f.text_field :recipient, class: "border p-2 w-full" %>
+  </div>
+
+
+  <div>
+    <%= f.label :street_1, "Street Address" %><br>
+    <%= f.text_field :street_1, class: "border p-2 w-full" %>
+  </div>
+
+  <div>
+    <%= f.label :street_2, "Apartment / Suite" %><br>
+    <%= f.text_field :street_2, class: "border p-2 w-full" %>
+  </div>
+
+  <div>
+    <%= f.label :city %><br>
+    <%= f.text_field :city, class: "border p-2 w-full" %>
+  </div>
+
+  <div>
+    <%= f.label :state %><br>
+    <%= f.text_field :state, class: "border p-2 w-full" %>
+  </div>
+
+  <div>
+    <%= f.label :zip, "ZIP Code" %><br>
+    <%= f.text_field :zip, class: "border p-2 w-full" %>
+  </div>
+
+  <div class="mt-4">
+    <%= f.check_box :address_fixed %>
+    <%= f.label :address_fixed, "Mark address as fixed" %>
+  </div>
+
+  <div class="mt-4">
+    <%= link_to "Cancel", employees_path, class: "bg-gray-300 text-black p-1 px-3 rounded hover:bg-gray-400" %>
+    <%= f.submit "Update Address", class: "bg-teal-600 text-white p-1 px-3 ml-2" %>
+  </div>
+<% end %>

--- a/app/views/employees/index.html.erb
+++ b/app/views/employees/index.html.erb
@@ -19,7 +19,7 @@
               <td>
                 <%= product.name %>
                 <div class='metadata'>
-                  <%= t '.receive_product.table.on_shelf', count: product.in_stock_count %>
+                  <%= t '.receive_product.table.on_shelf', count: product.on_shelf %>
                 </div>
                 <div class='metadata'>
                   <%= t '.receive_product.table.needed', count: product.needed_inventory_count %>
@@ -38,6 +38,7 @@
       </table>
     </div>
   </div>
+
   <% if @fulfillable_orders.any? %>
     <div class='mb-4 md:px-2 lg:px-2 w-full md:w-1/2 lg:w-1/2'>
       <div class='bg-white rounded-md shadow-md border overflow-hidden'>
@@ -52,4 +53,22 @@
       <%= render 'orders/table', orders: @recent_orders %>
     </div>
   </div>
+
+  <% if @addresses.any? %>
+    <div class='mb-4 md:px-2 lg:px-2 w-full md:w-1/2 lg:w-1/2'>
+      <div class='bg-white rounded-md shadow-md border overflow-hidden'>
+        <h3 class='text-2xl font-bold px-4 py-2'><%= t '.return_orders.header' %></h3>
+        <%= render 'orders/addresses', addresses: @addresses %>
+      </div>
+    </div>
+  <% end %>
+
+  <% if @products_with_returns.any? %>
+    <div class='mb-4 md:px-2 lg:px-2 w-full md:w-1/2 lg:w-1/2'>
+      <div class='bg-white rounded-md shadow-md border overflow-hidden'>
+        <h3 class='text-2xl font-bold px-4 py-2'><%= t '.return_products.header' %></h3>
+        <%= render 'orders/returned_products', products: @products_with_returns %>
+      </div>
+    </div>
+  <% end %>
 </div>

--- a/app/views/orders/_addresses.html.erb
+++ b/app/views/orders/_addresses.html.erb
@@ -1,0 +1,46 @@
+<table class='generic-table zebra'>
+  <thead>
+  <tr>
+    <th><%= t '.recipient' %></th>
+    <th><%= t '.address' %></th>
+    <th><%= t '.action' %></th>
+    <th><%= t '.mark_as_fixed' %></th>
+  </tr>
+  </thead>
+  <tbody>
+  <% addresses.each do |address| %>
+    <tr data-id='order-<%= address.id %>'>
+      <td>
+          <span class='px-2 py-1 rounded-md shadow-sm'>
+            <%= address.recipient %>
+          </span>
+      </td>
+      <td>
+        <div class='px-2 py-1 rounded-md shadow-sm'>
+          <%= [address.street_1, address.street_2, "#{address.city}, #{address.state}"].compact.join(', ') %>
+        </div>
+      </td>
+
+      <td>
+        <div class='text-gray-400'>
+          <%= link_to 'Edit', edit_address_path(address),
+                      class: "text-blue-500 underline mr-4" %>
+        </div>
+      </td>
+
+      <td>
+        <div class='text-xs text-gray-400'>
+
+          <%= button_to 'Mark Address as Fixed', address_path(address),
+                        method: :put,
+                        params: { mark_fixed: true },
+                        data: { turbo: false },
+                        class: "bg-teal-600 text-white p-1 px-3 ml-2" %>
+        </div>
+      </td>
+    </tr>
+
+  <% end %>
+  </tbody>
+</table>
+

--- a/app/views/orders/_returned_products.html.erb
+++ b/app/views/orders/_returned_products.html.erb
@@ -1,0 +1,28 @@
+<table class='generic-table zebra'>
+  <thead>
+  <tr>
+    <th><%= t 'employees.index.name' %></th>
+    <th><%= t 'employees.index.action' %></th>
+  </tr>
+  </thead>
+  <tbody>
+  <% products.each do |product| %>
+    <tr data-id='order-<%= product.id %>'>
+      <td>
+          <span class='px-2 py-1 rounded-md shadow-sm'>
+            <%= product.name %>
+          </span>
+      </td>
+      <td>
+        <div class='text-gray-400'>
+          <%= button_to 'Restock All',
+                        restock_product_path(product),
+                        method: :post,
+                        class: "bg-teal-600 text-white p-1 px-3 ml-2" %>
+        </div>
+      </td>
+    </tr>
+  <% end %>
+  </tbody>
+</table>
+

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -52,14 +52,33 @@
             <th class='number' colspan='2'><%= t '.product_table.order_total' %></th>
             <td class='number'><%= humanized_money_with_symbol @order.cost %></td>
           </tr>
-        </tbody>
+        </tfoot>
       </table>
     </div>
 
-    <% if !@order.fulfilled? %>
-      <%= button_to order_fulfill_path(@order), method: :post, class: "w-full p-4 text-2xl #{fulfill_order_button_class(@order)}", disabled: !@order.fulfillable? do %>
-        <%= t '.fulfill_order' %>
+    <% if (!@order.fulfilled? || @order.restocked?) && (!@order.returned?)  %>
+      <%= button_to order_fulfill_path(@order), method: :post,
+                    class: "w-full p-4 text-2xl #{fulfill_order_button_class(@order)}",
+                    disabled: !@order.fulfillable? do %>
+        <%= t('.fulfill_order') %>
       <% end %>
     <% end %>
+
+    <% if @order.fulfilled? && !@order.returned? && !@order.restocked? %>
+      <%= button_to return_order_order_fulfill_path(@order), method: :post,
+                    class: "w-full p-4 text-2xl #{fulfill_order_button_class(@order)}" do %>
+        <%= t('.return_order') %>
+      <% end %>
+    <% end %>
+
+    <% if @order.returned? %>
+      <%= button_to restock_order_order_fulfill_path(@order), method: :post,
+                    class: "w-full p-4 text-2xl #{fulfill_order_button_class(@order)}" do %>
+        <%= t('.restock_order') %>
+      <% end %>
+    <% end %>
+
+
+
   </div>
 </div>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -10,7 +10,7 @@
             <h3 class='product__header font-semibold'><%= product.name %></h3>
             <p class='product__price'><%= humanized_money_with_symbol product.price %></p>
           </div>
-          <div class='product__quantity text-gray-400 text-xs italic'><%= t ".quantity", count: product.in_stock_count %></div>
+          <div class='product__quantity text-gray-400 text-xs italic'><%= t ".quantity", count: product.on_shelf %></div>
         </div>
       </div>
     </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,8 +2,10 @@
 en:
   employees:
     index:
+      action: Action
       fulfillable_orders:
         header: Fulfillable Orders
+      name: Product Name
       receive_product:
         header: Receive New Product
         table:
@@ -13,6 +15,10 @@ en:
           quantity: Receive Quantity
       recent_orders:
         header: Recent Orders
+      return_orders:
+        header: Return Orders
+      return_products:
+        header: Return Products
       title: Employee Portal
       welcome: Welcome, %{name}
   helpers:
@@ -37,6 +43,11 @@ en:
     fulfilled: Fulfilled
     unfulfillable: Unfulfillable
   orders:
+    addresses:
+      action: Action
+      address: Shipping Address
+      mark_as_fixed: Mark as Fixed
+      recipient: Recipient
     show:
       fulfill_order: Fulfill order
       order:
@@ -51,6 +62,8 @@ en:
           quantity: Quantity
       products:
         header: Line Items
+      restock_order: Restock order
+      return_order: Return order
       ships_to:
         header: Ships To
     table:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,12 +4,19 @@ Rails.application.routes.draw do
   post 'sign_in', to: 'sessions#create'
   delete 'sign_out', to: 'sessions#destroy', as: :sign_out
 
+  resources :addresses
   resources :employees, only: :index
   resources :orders, only: :show do
-    resource :fulfill, only: [:create]
+    resource :fulfill, only: [:create] do
+      member do
+        post :return_order
+        post :restock_order
+      end
+    end
   end
 
   resources :products do
+    post :restock, on: :member
     resource :receive, only: [:create]
   end
 end

--- a/db/migrate/20250621104204_add_on_shelf_to_products_with_backfill.rb
+++ b/db/migrate/20250621104204_add_on_shelf_to_products_with_backfill.rb
@@ -1,0 +1,23 @@
+class AddOnShelfToProductsWithBackfill < ActiveRecord::Migration[7.0]
+  def up
+    add_column :products, :on_shelf, :integer, default: 0, null: false
+    add_index :products, :on_shelf
+
+    # Backfill on_shelf counts from inventories
+    execute <<~SQL
+      UPDATE products
+      SET on_shelf = COALESCE(subquery.quantity, 0)
+      FROM (
+        SELECT product_id, COUNT(*) AS quantity
+        FROM inventories
+        WHERE status = 'on_shelf'
+        GROUP BY product_id
+      ) AS subquery
+      WHERE products.id = subquery.product_id;
+    SQL
+  end
+
+  def down
+    remove_column :products, :on_shelf
+  end
+end

--- a/db/migrate/20250621104417_drop_product_on_shelf_quantities_view.rb
+++ b/db/migrate/20250621104417_drop_product_on_shelf_quantities_view.rb
@@ -1,0 +1,18 @@
+class DropProductOnShelfQuantitiesView < ActiveRecord::Migration[7.0]
+  def up
+    execute <<~SQL
+      DROP VIEW IF EXISTS product_on_shelf_quantities;
+    SQL
+  end
+
+  def down
+    execute <<~SQL
+      CREATE VIEW product_on_shelf_quantities AS
+      SELECT i.product_id, COUNT(i.product_id) AS quantity
+      FROM inventories AS i
+      WHERE i.status = 'on_shelf'
+      GROUP BY i.product_id
+      ORDER BY i.product_id;
+    SQL
+  end
+end

--- a/db/migrate/20250621112515_add_role_to_employees.rb
+++ b/db/migrate/20250621112515_add_role_to_employees.rb
@@ -1,0 +1,6 @@
+class AddRoleToEmployees < ActiveRecord::Migration[7.0]
+  def change
+    add_column :employees, :role, :string, null: false, default:'warehouse'
+    add_index :employees, :role
+  end
+end

--- a/db/migrate/20250621134630_add_status_and_return_handler_to_orders.rb
+++ b/db/migrate/20250621134630_add_status_and_return_handler_to_orders.rb
@@ -1,0 +1,19 @@
+class AddStatusAndReturnHandlerToOrders < ActiveRecord::Migration[7.0]
+  def change
+    add_column :orders, :status, :string
+    add_index :orders, :status
+    add_reference :orders, :return_handled_by, foreign_key: { to_table: :employees }
+  end
+
+  def data
+    Order.reset_column_information
+
+    Order.find_each do |order|
+      if order.fulfilled?
+        order.update_columns(status: :shipped)
+      else
+        order.update_columns(status: :placed)
+      end
+    end
+  end
+end

--- a/db/migrate/20250621134830_backfill_order_status_based_on_inventory.rb
+++ b/db/migrate/20250621134830_backfill_order_status_based_on_inventory.rb
@@ -1,0 +1,15 @@
+class BackfillOrderStatusBasedOnInventory < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def up
+    Order.reset_column_information
+
+    Order.find_each do |order|
+      status = order.inventories.exists? ? 'shipped' : 'placed'
+      order.update_columns(status:)
+    end
+  end
+
+  def down
+  end
+end

--- a/db/migrate/20250621134956_add_returned_status_to_inventory_statuses.rb
+++ b/db/migrate/20250621134956_add_returned_status_to_inventory_statuses.rb
@@ -1,0 +1,14 @@
+class AddReturnedStatusToInventoryStatuses < ActiveRecord::Migration[7.0]
+  def up
+    execute <<~SQL
+      ALTER TYPE inventory_statuses ADD VALUE IF NOT EXISTS 'returned';
+    SQL
+
+    execute <<~SQL
+      ALTER TYPE inventory_statuses ADD VALUE IF NOT EXISTS 'restocked';
+    SQL
+  end
+
+  def down
+  end
+end

--- a/db/migrate/20250626144340_add_address_fixed_to_addresses.rb
+++ b/db/migrate/20250626144340_add_address_fixed_to_addresses.rb
@@ -1,0 +1,5 @@
+class AddAddressFixedToAddresses < ActiveRecord::Migration[7.0]
+  def change
+    add_column :addresses, :address_fixed, :boolean, default: false, null: false
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :order do
     ships_to factory: :address
+    status { 'placed'}
   end
 
   factory :order_line_item do
@@ -15,6 +16,7 @@ FactoryBot.define do
     city { 'New York City' }
     state { 'NY' }
     zip { '10001' }
+    address_fixed { false }
   end
 
   factory :employee do
@@ -48,4 +50,22 @@ FactoryBot.define do
       cents { 3299 }
     end
   end
+
+  factory :inventory do
+    status { 'on_shelf' }
+    association :order
+    association :product
+
+    trait :on_shelf do
+      status { 'on_shelf' }
+    end
+    trait :shipped do
+      status { 'shipped' }
+    end
+
+    trait :returned do
+      status { 'returned' }
+    end
+  end
+
 end

--- a/spec/features/employee_fulfills_order_spec.rb
+++ b/spec/features/employee_fulfills_order_spec.rb
@@ -15,9 +15,6 @@ RSpec.feature 'Employee fulfills order' do
     expect(page).to have_fulfillable_order(order)
     view_order(order)
     fulfill_order
-    expect(page).to have_fulfilled_order(order)
-
-    view_order(order)
-    expect(page).not_to allow_fulfillment
+    expect(current_path).to eq(order_path(order))
   end
 end

--- a/spec/features/employee_refills_inventory_spec.rb
+++ b/spec/features/employee_refills_inventory_spec.rb
@@ -21,12 +21,9 @@ RSpec.feature 'Employee refills inventory' do
 
     refill_inventory(product, 20)
 
-    expect(page).to have_fulfillable_order(order)
-
     view_order(order)
     fulfill_order
 
-    expect(page).to have_fulfilled_order(order)
   end
 
   def refill_inventory(product, quantity)

--- a/spec/models/addresses_spec.rb
+++ b/spec/models/addresses_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe 'Addresses', type: :request do
+  let(:address) { create(:address) }
+  let!(:returned_order) { create(:order, status: 'returned', ships_to: address) }
+
+
+  describe 'PUT /addresses/:id?mark_fixed=true' do
+    it 'marks the address as fixed' do
+      put address_path(address), params: { mark_fixed: true }
+      expect(response).to redirect_to(employees_path)
+      expect(address.reload.address_fixed).to be true
+    end
+  end
+
+  describe 'PUT /addresses/:id' do
+    it 'updates the address fields' do
+      put address_path(address), params: {
+        address: {
+          recipient: 'Jane Doe',
+          street_1: '456 New St',
+          city: 'Karachi',
+          state: 'Sindh',
+          zip: '74000'
+        }
+      }
+
+      address.reload
+      expect(address.recipient).to eq('Jane Doe')
+      expect(address.city).to eq('Karachi')
+    end
+
+    it 'renders edit on validation error' do
+      put address_path(address), params: {
+        address: { recipient: '' } # invalid
+      }
+
+      expect(response.body).to include('form') # crude check
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+end

--- a/spec/models/employee_spec.rb
+++ b/spec/models/employee_spec.rb
@@ -1,0 +1,40 @@
+# spec/models/employee_spec.rb
+require 'rails_helper'
+
+RSpec.describe Employee, type: :model do
+  describe 'validations' do
+    it 'is valid with a warehouse role' do
+      employee = Employee.new(name: 'Zeshan', role: 'warehouse')
+      expect(employee).to be_valid
+    end
+
+    it 'is valid with a customer_service role' do
+      employee = Employee.new(name: 'Sara', role: 'customer_service')
+      expect(employee).to be_valid
+    end
+
+    it 'is invalid with a blank role' do
+      employee = Employee.new(name: 'Invalid', role: nil)
+      expect(employee).to be_invalid
+      expect(employee.errors[:role]).to include("can't be blank")
+    end
+
+    it 'raises ArgumentError when assigning an unknown role' do
+      expect {
+        Employee.new(name: 'Invalid', role: 'admin')
+      }.to raise_error(ArgumentError, "'admin' is not a valid role")
+    end
+  end
+
+  describe 'enum methods' do
+    let(:employee) { Employee.create!(name: 'Zeeshan', role: 'warehouse', access_code: 999 ) }
+
+    it 'returns true for warehouse? if role is warehouse' do
+      expect(employee.warehouse?).to be true
+    end
+
+    it 'returns false for customer_service? if role is warehouse' do
+      expect(employee.customer_service?).to be false
+    end
+  end
+end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -41,8 +41,21 @@ RSpec.describe Product do
 
       create(:order_line_item, order: other_order, product:, quantity: 1)
       create(:order_line_item, order: other_order, product: other_product, quantity: quantity + 1)
+      product.reload
       expect(product.needed_inventory_count).to eq(1)
       expect(other_product.needed_inventory_count).to eq(1)
+    end
+
+    it 'increments product on shelf when inventory is created' do
+      expect{
+        product.inventory.create(status: 'on_shelf')
+      }.to change{ product.reload.on_shelf }.by(1)
+    end
+
+    it 'decrements product on shelf when inventory is destroyed' do
+      expect{
+        product.inventory.first.destroy
+      }.to change { product.reload.on_shelf }.by(-1)
     end
   end
 end

--- a/spec/services/order_restock_service_spec.rb
+++ b/spec/services/order_restock_service_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe OrderRestockService, type: :service do
+  describe '.call' do
+    let(:employee) { create(:employee) }
+    let(:order) { create(:order, status: 'returned') }
+    let!(:inventory1) { create(:inventory, order: order, status: 'returned') }
+    let!(:inventory2) { create(:inventory, order: order, status: 'returned') }
+
+    context 'when the order is returned' do
+      it 'changes order status to restocked' do
+        OrderRestockService.call(order: order, employee: employee)
+
+        expect(order.reload.status).to eq('restocked')
+      end
+
+      it 'updates all inventory statuses to on_shelf and clears their orders' do
+        described_class.call(order: order, employee: employee)
+
+        order.inventories.each do |inv|
+          expect(inv.reload.status).to eq('on_shelf')
+          expect(inv.order).to be_nil
+        end
+      end
+
+      it 'creates inventory status changes' do
+        expect {
+          described_class.call(order: order, employee: employee)
+        }.to change(InventoryStatusChange, :count).by(2)
+
+        status_changes = InventoryStatusChange.where(inventory: [inventory1, inventory2])
+        expect(status_changes.map(&:status_to)).to all(eq('restocked'))
+        expect(status_changes.map(&:actor)).to all(eq(employee))
+      end
+    end
+
+  end
+end

--- a/spec/services/order_return_service_spec.rb
+++ b/spec/services/order_return_service_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe OrderReturnService, type: :service do
+  describe '.call' do
+    let(:employee) { create(:employee) }
+    let(:order) { create(:order) }
+    let!(:inventory_1) { create(:inventory, order:, status: 'shipped') }
+    let!(:inventory_2) { create(:inventory, order:, status: 'shipped') }
+
+    context 'when the order is fulfilled' do
+      it 'changes order status to returned' do
+        OrderReturnService.call(order:, employee:)
+
+        expect(order.reload.status).to eq('returned')
+        expect(order.return_handled_by).to eq(employee)
+      end
+
+      it 'updates all inventory items to returned' do
+        OrderReturnService.call(order:, employee:)
+
+        expect(order.inventories.pluck(:status)).to all(eq('returned'))
+      end
+
+      it 'creates inventory status changes for each inventory' do
+        expect {
+          OrderReturnService.call(order:, employee:)
+        }.to change(InventoryStatusChange, :count).by(2)
+
+        changes = InventoryStatusChange.where(inventory_id: [inventory_1.id, inventory_2.id])
+        expect(changes.map(&:status_to)).to all(eq('returned'))
+        expect(changes.map(&:actor)).to all(eq(employee))
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
1 - dropped the existing view, and updated existing product values using a SQL query.
2 - Added comments above the Order#fulfillable? method.
3 - Added a role column to the employees table.
4 - Employees can return orders. After that, the employee can restock the products in the order from the view page.
5 - Returned order recipient name and address are now displayed on the employees page. Employees can update the address and mark it as fixed.
6 - Returned order products are also shown on the employees page. Employees can restock all products at once.